### PR TITLE
Update to sankey readme

### DIFF
--- a/src/examples/sankey/README.md
+++ b/src/examples/sankey/README.md
@@ -3,7 +3,7 @@
 
 ![](sankey.png)
 
-This diagram creates a [sankey diagram](https://en.wikipedia.org/wiki/Sankey_diagram) to display sequences of transitions. Sankey diagrams are a specific type of flow diagram, in which the width of each arrow is shown proportionally to the flow quantity. Sankey diagrams are often used in scientific fields, especially physics. They are used to represent energy inputs, useful output, and wasted output. Sankeys can also be used to understand how users arrive at and navigate through an application or website.
+This visualization creates a [sankey diagram](https://en.wikipedia.org/wiki/Sankey_diagram), which displays sequences of transitions. Sankey diagrams are a specific type of flow diagram, in which the width of each arrow is proportional to the flow quantity. Sankey diagrams are often used in scientific fields, especially physics. They are used to represent energy inputs, useful outputs, and wasted outputs. Sankeys can also be used to understand how users arrive at and navigate through an application or website.
 
 Good use cases include: 
 - Event Analytics
@@ -14,7 +14,7 @@ Good use cases include:
 
 **How it works**
 
-Create a look with any number of dimensions and one measure.
+Create a Look with any number of dimensions and one measure.
 
 For example, in the sankey diagram above, you can see event transition counts between the various sequences of states.
 

--- a/src/examples/sankey/README.md
+++ b/src/examples/sankey/README.md
@@ -3,7 +3,12 @@
 
 ![](sankey.png)
 
-This diagram creates a [sankey diagram](https://en.wikipedia.org/wiki/Sankey_diagram) to display sequences of transitions.
+This diagram creates a [sankey diagram](https://en.wikipedia.org/wiki/Sankey_diagram) to display sequences of transitions. Sankey diagrams are a specific type of flow diagram, in which the width of each arrow is shown proportionally to the flow quantity. Sankey diagrams are often used in scientific fields, especially physics. They are used to represent energy inputs, useful output, and wasted output. Sankeys can also be used to understand how users arrive at and navigate through an application or website.
+
+Good use cases include: 
+- Event Analytics
+- Energy Flows
+- Order Stages
 
 ![](sankey.mov)
 


### PR DESCRIPTION
- Fixed "S ankey"
- "in which the width of the arrows is shown proportionally..." ==> "...in which the width of each band is shown proportionally..." 
- "fields of science" ==> "scientific fields"
- **Question:** Would it make sense to edit "This diagram creates a sankey diagram..."? Change to "This code/script/? creates a sankey diagram..."??