### PR TITLE
Add color application to docs

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -261,6 +261,11 @@ Here's an example:
 
 ```js
 options: {
+    color_application: {
+      type: 'object',
+      display: 'color_application',
+      label: 'Color Configuration',
+    },
     color_range: {
       type: "array",
       label: "Color Range",
@@ -293,7 +298,7 @@ options: {
 
 	The data type of the option.
 
-	**Allowed Values:** `string` (default), `number`, `boolean`, `array`
+	**Allowed Values:** `string` (default), `number`, `boolean`, `array`, `object`
 
 - `label` _string_
 
@@ -318,6 +323,10 @@ options: {
 	- when `type` is `array`:
 
 	   	**Allowed Values:** `text` (default), `color`, `colors`
+		
+	- when `type` is `object`:
+	
+		**Allowed Values:** `color_application`
 
 - `placeholder` _string_
 


### PR DESCRIPTION
color_application gives developers access to color collections


<img width="276" alt="Screen Shot 2020-01-28 at 9 22 38 AM" src="https://user-images.githubusercontent.com/6431282/73283013-b3cf2200-41af-11ea-8476-e5b62fc5fa51.png">