### PR TITLE
Revert "Add color application to docs"

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -261,11 +261,6 @@ Here's an example:
 
 ```js
 options: {
-    color_application: {
-      type: 'object',
-      display: 'color_application',
-      label: 'Color Configuration',
-    },
     color_range: {
       type: "array",
       label: "Color Range",
@@ -298,7 +293,7 @@ options: {
 
 	The data type of the option.
 
-	**Allowed Values:** `string` (default), `number`, `boolean`, `array`, `object`
+	**Allowed Values:** `string` (default), `number`, `boolean`, `array`
 
 - `label` _string_
 
@@ -323,10 +318,6 @@ options: {
 	- when `type` is `array`:
 
 	   	**Allowed Values:** `text` (default), `color`, `colors`
-		
-	- when `type` is `object`:
-	
-		**Allowed Values:** `color_application`
 
 - `placeholder` _string_
 


### PR DESCRIPTION
Reverts looker/custom_visualizations_v2#126

There are a few issues conveying the contents of the color collections themselves that make this an incomplete implementation. The UI shows up but we only pass color collection Ids. Will revert this PR once it's fixed in Looker. Ideally we should detail each and every configuration better than we do currently anyway.